### PR TITLE
fix missing var

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -114,7 +114,7 @@ class logstashforwarder::package {
             source  => $source_path,
             require => File[$package_dir],
             backup  => false,
-            before  => before
+            before  => $before
           }
 
         }


### PR DESCRIPTION
when use package the error "Parameter before failed: No title provided and "before" is not a valid resource reference" searching the solution find the missing "$".