### PR TITLE
module does not work because of some bugs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,7 +89,7 @@ class logstashforwarder::params {
   # Different path definitions
   case $::kernel {
     'Linux': {
-      $configdir = '/etc/logstashforwarder'
+      $configdir = '/etc/logstash-forwarder'
       $package_dir = '/opt/logstashforwarder/swdl'
       $installpath = '/opt/logstashforwarder'
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -42,6 +42,7 @@ class logstashforwarder::repo {
     }
     'RedHat': {
       yumrepo { 'logstashforwarder':
+	name => 'logstashforwarder',
         baseurl  => 'http://packages.elasticsearch.org/logstashforwarder/centos',
         gpgcheck => 1,
         gpgkey   => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -42,7 +42,7 @@ class logstashforwarder::repo {
     }
     'RedHat': {
       yumrepo { 'logstashforwarder':
-	name => 'logstashforwarder',
+	name => 'elasticsearch logstashforwarder',
         baseurl  => 'http://packages.elasticsearch.org/logstashforwarder/centos',
         gpgcheck => 1,
         gpgkey   => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',


### PR DESCRIPTION
when using the manage_repo => true the init-script uses the /etc/logstash-forwarder directory but the module will create /etc/logstashforwarder instead

tested on centos 6.5