### PR TITLE
Debian init script workaround

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -130,6 +130,11 @@ class logstashforwarder::config {
       notify => $notify_service
     }
 
+    file { '/etc/logstash-forwarder':
+      ensure => link,
+      target => "${logstashforwarder::configdir}/config.json";
+    }
+
   } elsif ( $logstashforwarder::ensure == 'absent' ) {
 
     file { $logstashforwarder::configdir:


### PR DESCRIPTION
In debian installations the init script expects to find the config file for logstash-forwarder at /etc/logstash-forwarder

This fix is to put a symlink there pointing to ${logstashforwarder::configdir}/config.json where it is created by this module.