### PR TITLE
make logstashforwarder_config depend on the parent directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -121,13 +121,14 @@ class logstashforwarder::config {
     $main_config = "{\n  \"network\": {\n    \"servers\": ${opt_servers},\n    \"ssl certificate\": \"${opt_ssl_cert}\",\n    \"ssl ca\": \"${opt_ssl_ca}\",\n    \"ssl key\": \"${opt_ssl_key}\",\n    \"timeout\": ${opt_timeout}\n  },"
 
     logstashforwarder_config { 'lsf-config':
-      ensure => 'present',
-      config => $main_config,
-      path   => "${logstashforwarder::configdir}/config.json",
-      tag    => "LSF_CONFIG_${::fqdn}",
-      owner  => $logstashforwarder::logstashforwarder_user,
-      group  => $logstashforwarder::logstashforwarder_group,
-      notify => $notify_service
+      ensure  => 'present',
+      config  => $main_config,
+      path    => "${logstashforwarder::configdir}/config.json",
+      tag     => "LSF_CONFIG_${::fqdn}",
+      owner   => $logstashforwarder::logstashforwarder_user,
+      group   => $logstashforwarder::logstashforwarder_group,
+      notify  => $notify_service,
+      require => File[$logstashforwarder::configdir],
     }
 
   } elsif ( $logstashforwarder::ensure == 'absent' ) {


### PR DESCRIPTION
Require our parent directory before writing config.json, otherwise it periodically generates errors like:

```
Error: Could not set 'present' on ensure: No such file or directory - /etc/logstashforwarder/config.json at 131:/etc/puppet/environments/production/modules/logstashforwarder/manifests/config.pp
Wrapped exception:
No such file or directory - /etc/logstashforwarder/config.json
Error: /Stage[main]/Logstashforwarder::Config/Logstashforwarder_config[lsf-config]/ensure: change from absent to present failed: Could not set 'present' on ensure: No such file or directory - /etc/logstashforwarder/config.json at 131:/etc/puppet/environments/production/modules/logstashforwarder/manifests/config.pp
```