### PR TITLE
switch to the full 40 character GPG fingerprint for apt keys

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,7 +39,7 @@ class logstashforwarder::repo {
         location    => 'http://packages.elasticsearch.org/logstashforwarder/debian',
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
         key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
This commit replaces the 8-character apt key value with the full 40 character one (I noticed this was producing a warning when used with puppetlabs-apt 1.8.0 and puppet 3.8.1). I saw other references to the short GPG fingerprint for Suse, but left them as-is, since I think the long key is really only required for puppetlabs-apt.

This should fix #36 