### PR TITLE
added config_file_path param

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -123,7 +123,7 @@ class logstashforwarder::config {
     logstashforwarder_config { 'lsf-config':
       ensure  => 'present',
       config  => $main_config,
-      path    => '/etc/logstash-forwarder.conf',
+      path    => $logstashforwarder::config_file_path,
       tag     => "LSF_CONFIG_${::fqdn}",
       owner   => $logstashforwarder::logstashforwarder_user,
       group   => $logstashforwarder::logstashforwarder_group,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,6 +50,13 @@ class logstashforwarder::config {
       false => undef,
     }
 
+    file { "$logstashforwarder::configdir/conf.d":
+      ensure => directory,
+      owner  => root,
+      group  => root,
+      mode   => 755,
+    }
+
     file { $logstashforwarder::configdir:
       ensure => directory,
       mode   => '0644',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,13 +50,6 @@ class logstashforwarder::config {
       false => undef,
     }
 
-    file { "$logstashforwarder::configdir/conf.d":
-      ensure => directory,
-      owner  => root,
-      group  => root,
-      mode   => 755,
-    }
-
     file { $logstashforwarder::configdir:
       ensure => directory,
       mode   => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,9 @@
 #   Path to directory containing the Logstash Forwarder configuration.
 #   Use this setting if your packages deviate from the norm (/etc/logstashforwarder)
 #
+# [*config_file_path*]
+#   Path to the main Logstash Forwarder configuration file.
+#
 # [*package_url*]
 #   Url to the package to download.
 #   This can be a http,https or ftp resource for remote packages
@@ -171,6 +174,7 @@ class logstashforwarder(
   $logstashforwarder_user  = $logstashforwarder::params::logstashforwarder_user,
   $logstashforwarder_group = $logstashforwarder::params::logstashforwarder_group,
   $configdir               = $logstashforwarder::params::configdir,
+  $config_file_path        = $logstashforwarder::params::config_file_path,
   $purge_configdir         = $logstashforwarder::params::purge_configdir,
   $service_provider        = 'init',
   $init_defaults           = $logstashforwarder::params::init_defaults,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,6 +54,8 @@ class logstashforwarder::params {
   # Exec timeout
   $package_dl_timeout = 300  # 300 seconds is default of Puppet
 
+  $config_file_path = '/etc/logstash-forwarder.conf'
+
   #### Internal module values
 
   # User and Group for the files and user to run the service as.


### PR DESCRIPTION
I had the need to specify the main config logstash forwarder config file path, so I added `$config_file_path`.  It defaults to the value that was previously hardcoded which is `/etc/logstash-forwarder.conf`.  This may be useful for anyone who needs to override it for whatever reason.