### PR TITLE
Fixes #58 - Update Gemfile to convert git into https to avoid RSA Key issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1
 before_install: rm Gemfile.lock || true
 script: 
  - "bundle exec rake lint"
@@ -15,6 +16,23 @@ env:
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.5.0"
 matrix:
-  allow_failures:
-    - rvm: 2.0.0
+  exclude:
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.1.0"
+  - rvm: 2.1
+    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.1
+    env: PUPPET_VERSION="~> 3.1.0"
+  - rvm: 2.1
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.1
+    env: PUPPET_VERSION="~> 3.3.0"
+  - rvm: 2.1
+    env: PUPPET_VERSION="~> 3.4.0"
+

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 puppetversion = ENV['PUPPET_VERSION'] || '~> 3.7.0'
 gem 'puppet', puppetversion, :require => false
 
-gem 'beaker', :git => 'git@github.com:puppetlabs/beaker.git', :branch => 'master'
-gem 'beaker-rspec', :git => 'git@github.com:puppetlabs/beaker-rspec.git', :branch => 'master'
+gem 'beaker', :git => 'https://github.com/puppetlabs/beaker.git', :branch => 'master'
+gem 'beaker-rspec', :git => 'https://github.com/puppetlabs/beaker-rspec.git', :branch => 'master'
 gem 'metadata-json-lint', :git => 'https://github.com/nibalizer/metadata-json-lint.git', :branch => 'master'
 gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git', :branch => 'master'
 


### PR DESCRIPTION
```
Retrying git clone 'git@github.com:puppetlabs/beaker.git' "/home/travis/.rvm/gems/ruby-1.9.3-p551/cache/bundler/git/beaker-18670cc1b84a185c2066a67869906a4430a4c4a8" --bare --no-hardlinks --quiet due to error (2/4): Bundler::Source::Git::GitCommandError Git error: command `git clone 'git@github.com:puppetlabs/beaker.git' "/home/travis/.rvm/gems/ruby-1.9.3-p551/cache/bundler/git/beaker-18670cc1b84a185c2066a67869906a4430a4c4a8" --bare --no-hardlinks --quiet` in directory /home/travis/build/elastic/puppet-logstashforwarder has failed.
Warning: Permanently added the RSA host key for IP address '192.30.252.131' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
```
This error message is due to the use of the git protocol which needs an SSH Key use.
To avoid this, we need t use the https protocol instead.
 